### PR TITLE
The annoying space tweak

### DIFF
--- a/authors.php
+++ b/authors.php
@@ -23,6 +23,7 @@ foreach ($authors as $author):
         <?php echo wpautop($authorInfo->description); ?>
         <p>
         <?php if ($twitter = get_the_author_meta('twitter', $authorId)): ?><span>Twitter: <a href="http://twitter.com/<?php echo $twitter; ?>">@<?php echo $twitter; ?></a></span><?php endif; ?>
+        <?php if ($twitter = get_the_author_meta('twitter', $authorId)): && ($url = get_the_author_meta('user_url', $authorId)): ?><span>&nbsp;|&nbsp;</span><?php endif; ?>
         <?php if ($url = get_the_author_meta('user_url', $authorId)): ?><span>Site: <a href="<?php echo $url; ?>"><?php echo $authorInfo->user_firstname; ?>&#8217;s Site</a></span><?php endif; ?>
         </p>
     </div>


### PR DESCRIPTION
Added a line on the authors.php that checks if there's both a twitter and url. If that is the case then I add ' | '. Should be much prettier now... that is, as long as that php I just improvised works at all.
